### PR TITLE
fix first window not being transparent

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -84,6 +84,12 @@ import { VSBuffer } from 'vs/base/common/buffer';
 import { EncryptionMainService, IEncryptionMainService } from 'vs/platform/encryption/electron-main/encryptionMainService';
 import { ActiveWindowManager } from 'vs/platform/windows/common/windowTracker';
 
+function sleep(ms: any) {
+	return new Promise((resolve) => {
+		setTimeout(resolve, ms);
+	});
+}
+
 export class CodeApplication extends Disposable {
 	private windowsMainService: IWindowsMainService | undefined;
 	private dialogMainService: IDialogMainService | undefined;
@@ -323,6 +329,7 @@ export class CodeApplication extends Disposable {
 	}
 
 	async startup(): Promise<void> {
+		await sleep(400);
 		this.logService.debug('Starting VS Code');
 		this.logService.debug(`from: ${this.environmentService.appRoot}`);
 		this.logService.debug('args:', this.environmentService.args);


### PR DESCRIPTION
This PR fixes that the first window is transparent. I tested this patch on top of the [aur package](https://aur.archlinux.org/packages/code-transparent/?O=0&PP=10) but it should work here too.
This fix is based on the discussion on [https://github.com/electron/electron/issues/15947](https://github.com/electron/electron/issues/15947)